### PR TITLE
Fix cloudbuild.yaml link

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,4 +2,4 @@
 
 Images in this repository are built and released in the `gcr.io/distroless` repository on the [Google Container Registry](https://cloud.google.com/container-registry/).
 
-Images are automatically built and pushed every commit, according to the policy defined in [cloudbuild.yaml](/cloudbuild.yaml).
+Images are automatically built and pushed every commit, according to the policy defined in [cloudbuild.yaml](.cloudbuild/cloudbuild.yaml).


### PR DESCRIPTION
cloudbuild.yaml is inside .cloudbuild directory